### PR TITLE
fix: Incorrect styling due to SEQTA update

### DIFF
--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -57,7 +57,7 @@ select {
   transition: 200ms;
   background: var(--auto-background) !important;
 }
-* {
+:root * {
   font-family: Rubik, sans-serif !important;
   --theme-fg-parts: white;
 }


### PR DESCRIPTION
SEQTA decided to add some !important rules, breaking the top bars colour, and the logo in the sidebar on the most recent version as of now. This PR fixes that, and should be completely compatible with all prior versions (literally all this PR does is add 3 important rules of our own)