### PR TITLE
fix: fix bug in Vanilla SEQTA Causing unesasary reloads

### DIFF
--- a/src/css/injected.scss
+++ b/src/css/injected.scss
@@ -3550,6 +3550,16 @@ div.day-empty {
   scrollbar-width: none !important;
 }
 
+/* Fix SEQTA update: ul.logo-link covers sidebar and causes page reload on empty space clicks */
+#menu ul.logo-link {
+  pointer-events: none;
+
+  /* Re-enable clicks on menu items (li) - they're inside the logo-link ul */
+  li {
+    pointer-events: auto;
+  }
+}
+
 .notice-unified-content.notice-modal-state {
   border: none !important;
 }


### PR DESCRIPTION
After the recent TES Rebranding update **Version** `2026.2.2-master-20260213-227` a bug as been introduced in base SEQTA itself, the entire Navigation bar div gets wrapped in `class="logo-link"` meaning any empty space clicked force reloads the page to home screen. This also affects navigating SEQTA quickly, when a page is during animation clicking the area where the button would be if it hasn't finished its animation it force reloads being very annoying.

### This is a simple CSS fix to block pointer events in the empty space of the Nav