### PR TITLE
Fix: QR code gen issues on Firefox

### DIFF
--- a/src/interface/components/ConnectMobileApp.svelte
+++ b/src/interface/components/ConnectMobileApp.svelte
@@ -132,7 +132,7 @@
 {#if showQrModal && qrDataUrl}
   <div
     use:portal
-    class="fixed cursor-auto inset-0 z-[10000] flex justify-center items-center bg-black/50 backdrop-blur-sm"
+    class="fixed cursor-auto inset-0 z-[10000] flex justify-center items-center bg-black/50 {isStandalone ? 'backdrop-blur-sm' : ''}"
     role="button"
     tabindex="-1"
     onclick={(e) => {


### PR DESCRIPTION
Fixes #408
Fixes #409

Terms:
 - Embedded settings: The settings menu injected into the SEQTA page itself
 - Extension settings:  The settings menu accessed by clicking the BQ+ extension
---

Fixes:
 - Generation in the extension settings
 - Display of the popup in the embedded settings

Generation did not function because of Chrome reliant code, and display did not function properly due to an issue with Firefox itself in which a backdrop filter within a shadow dom will break drawing of the popup.