### PR TITLE
feat: each font option in the font picker uses its own font

### DIFF
--- a/src/interface/components/FontPickerModal.svelte
+++ b/src/interface/components/FontPickerModal.svelte
@@ -129,7 +129,12 @@
           data-font-id={preset.id}
         >
           <div class="bsplus-font-picker-option-head">
-            <span class="bsplus-font-picker-option-name">{preset.name}</span>
+            <span 
+              class="bsplus-font-picker-option-name"
+              style="font-family: {preset.stack} !important;"
+            >
+              {preset.name}
+            </span>
             {#if selectedId === preset.id}
               <span class="bsplus-font-picker-badge">Selected</span>
             {/if}


### PR DESCRIPTION
This PR makes each font picker option in the `FontPickerModal` font option list display using the font listed for each option.

Fixes #460 